### PR TITLE
Fix seq-zip to avoid spurious nils

### DIFF
--- a/src/fast_zip/core.clj
+++ b/src/fast_zip/core.clj
@@ -40,7 +40,7 @@
   {:added "1.0"}
   [root]
   (zipper seq?
-    identity
+    seq
     (fn [node children] (with-meta children (meta node)))
     root))
 


### PR DESCRIPTION
See CLJ-1317:

  http://dev.clojure.org/jira/browse/CLJ-1317

Credit for discovering the problem goes to Lee Spector. More comments on the Clojure ticket.

Note that this is a completely fresh issue, with no comments from Clojure/core on the patch.
